### PR TITLE
[codex] Update profile README for 2026

### DIFF
--- a/README.before-2026.md
+++ b/README.before-2026.md
@@ -1,0 +1,163 @@
+<!--
+[<img src="https://img.shields.io/badge/Github-%23eeeeee.svg?&style=for-the-badge&logo=github&logoColor=black">](https://github.com/Anmolnoor)
+[<img alt="Gmail" src="https://img.shields.io/badge/Gmail-D14836?style=for-the-badge&logo=gmail&logoColor=white" />](mailto:anmolnoor59@gmail.com)
+[<img src="https://img.shields.io/badge/linkedin-%230077B5.svg?&style=for-the-badge&logo=linkedin&logoColor=white">](https://www.linkedin.com/in/anmol-noor-47305013a)
+[<img alt="HackerRank" src="https://img.shields.io/badge/-Hackerrank-2EC866?style=for-the-badge&logo=HackerRank&logoColor=white"/>](https://www.hackerrank.com/anmolnoor59)
+--> 
+
+# Hello <img src="https://github.com/TheDudeThatCode/TheDudeThatCode/blob/master/Assets/Earth.gif" width="24px">, *About [Me](https://github.com/Anmolnoor)*:
+
+**I'm Computer Engineer with a keen interest in Coding.**
+
+<!-- - 🔭 I’m currently working at **[Dynamic Nexus Solutions](https://www.dynamicnexussolutions.com/)** -->
+
+- 💥 I'm Founder of **[Dynamic Nexus Solutions](https://www.dynamicnexussolutions.com/)** & **[Chain Commerce](https://github.com/Chain-Commerce)**
+
+- 🔭 I’m currently working with **MERN** | **Web3** | **Solana** | **webRTC** | **MediaSoup** | **Astro** | **Nextjs**
+
+- 🌱 I’m currently learning **CI/CD**
+
+- 👯 I’m looking to collaborate on **OpenSource Projects**
+
+- 👨‍💻 All of my projects are available at **[My Portfolio](https://anmolnoor.com)**
+
+- 📫 How to reach me **anmolnoor59@gmail.com** or book a [Meet](https://cal.com/anmolnoor)
+
+- ⚡ Fun fact I like **VSCode | Linux**
+
+# 🏫 *Education*:
+
+### Bachelor of Technology in Computer Science and Engineering.</br>
+2018-2022 - Bhai Gurdas Institute of Engineering and Technology, Sangrur.
+
+# ⚙️ *Skills*:
+
+- Web3 Developer 
+- Solana web3 Developer
+- React Native Development 
+- Android Development 
+- MERN Development 
+- Front-End with React, Next 
+- Back-End with NodeJS, Express, Axios 
+- Database Such as MongoDb, MySQL, Firebase 
+- CSS FrameWork BootStrap, Tailwind, Material_UI, Mantine
+- UI/UX Designing with Figma, AdobeXD, Photoshop 
+- Linux User & Git/GitHub 
+- Problem Solving & Interpersonal Skill 
+
+# 🛠️ *My Experience*:
+
+- **Frontend Engineer at [Huddle01](https://huddle01.com) - I have worked on frontend of [Huddle01](https://huddle01.com) website as Frontend Engineer. Also got the opportunity to work with webRTC, Mediasuop, Sockets.**
+
+- **React Native Intern at [Fortec Solution](https://fortecsolution.com/) - I have worked on Complaint Ticket Booking App of [Protocol Solutions](https://protocolsolution.com/). It was fully automated Ticket Generator using React-Native as Frontend and PHP based API. I have also work on App UI/UX.**
+
+- **Team Lead at [SWPL]() - I have worked with team of 5 Developer. We worked on Two projects, which are Rural Paisa and Full Stop in MERN Stack.**
+
+- **Web-Developer Internship at [ALS](https://autumnleavessolutions.com/)  - I have complete my 1 month Internship which include 3 projects. Such as Single Page website(landing page), College ERP, E-commerce (ReactJS).**
+
+
+
+# 💻 *Projects*:
+
+- **[NFT Droper](http://nft-drop-gold.vercel.app/)** It is a NFT droper on Solana Chain </br>
+- **[D-twitter](https://d-itter.netlify.app/#/)** It is a decentralised Twitter </br>
+- **[wallet-dapp](https://6205df9cef9c0122a08aba3a--sleepy-galileo-ce19c5.netlify.app/)** It is a Solana wallet playground </br>
+- **[Image-Portal](https://upbeat-bartik-f06847.netlify.app/)** It is a buildspace Solana IMG Portal Project </br>
+- **[solana-riptide-leader-board](http://solana-riptide-leader-board.vercel.app/)** Leader board of the Solana riptide Hackathon **XD** </br>
+- **[Flashback](https://github.com/Anmolnoor/flashback)** RealTime Social Media WebAPP with **_MERN_** along with **_uploading posts, like , share , delete._**</br>
+- **[Next Events](https://next-event-livid.vercel.app/)** It is a Nextjs application with all benefits of next js </br>
+- **[Meetup](https://meetup-smoky.vercel.app/)** It is a React application with all benefits of Reactjs </br>
+- **[Next Routing](https://next-routing-ebon.vercel.app/)** It is a Nextjs application for testing routing </br>
+- **[natours](https://natours-ej3e.onrender.com)** It is a **Full Backend** for a tours website with full security </br>
+- **[Reservation System](https://reservation-system-ten.vercel.app/)** It is a reservation system in TS </br>
+- **[_EJS and NodeJS + Express_](https://bgiet.onrender.com)** Based College Task management System.</br>
+- **[Node Farm](https://node-farm-vwne.onrender.com)** It is a website with just node js </br>
+- **[Security](https://security-syjk.onrender.com)** A Simple Login and Registration app with Implementing Various Encryptions Such as **_BcryptJS, OAuth, Hashing_**, etc.</br>
+- **[Todo List](https://todo-list-with-db.onrender.com)** A todo list with MongoDB database to store states </br>
+- **[Daily Journal](https://blog-with-database-41fd.onrender.com/)** Blog Application with **_MongoDB_** database on **_Express_** server.</br>
+- **[News letter](https://github.com/Anmolnoor/Newsletter-Singup)** It is a newsletter with Mailchimp </br>
+- **[Weather Project](https://github.com/Anmolnoor/weather-project)** app along with **_API_** from Open weather map.</br>
+- **[Simon Game](https://anmolnoor.github.io/Simon-Game/)** It is a Simon game </br>
+- **[Drum Kit](https://anmolnoor.github.io/Drum_Kit/)** It is a Drumkit in Website </br>
+- **[Dice Roll](https://anmolnoor.github.io/Dice_Roller/)** It is a Dice roller.</br>
+- **[Tindog](https://anmolnoor.me/TinDog/)** A tinder for dogs </br>
+- **[Vim Cheatsheet](https://github.com/Anmolnoor/vimCS/blob/main/README.md)**</br>
+- **[Markdown syntax Cheat sheet](https://github.com/Anmolnoor/markdownSCS/blob/main/README.md)**\
+
+Complaint Ticket Booking Project with **_React Native_** for Protocol Solutions.</br>
+A Login and Registration with **_JWT Tokens_** with Private routing and access control.</br>
+
+# 🔨 *Tech Stack I am Familiar With*:
+
+<p align="center" >
+<!-- <br/>  <a href="https://github.com/Anmolnoor/github-readme-stats"><img alt="Anmol Noor's Top Languages" src="https://github-readme-stats.vercel.app/api/top-langs/?username=Anmolnoor&langs_count=8&count_private=true&layout=compact&theme=react&hide_border=true&bg_color=0D1117" /></a> -->
+  <br/><br/>
+  <b>Note:</b> Top languages is only a metric of the languages my public code consists of and doesn't reflect experience or skill level.
+
+ <br/>
+  <img src="https://raw.githubusercontent.com/Anmolnoor/Anmolnoor/master/gif%20profile/68747470733a2f2f692e67697068792e636f6d2f6d656469612f49647941514a564e326b56504e55726f6a4d2f3230302e77656270.webp" width="50"><img src="https://raw.githubusercontent.com/Anmolnoor/Anmolnoor/master/gif%20profile/68747470733a2f2f692e67697068792e636f6d2f6d656469612f4c4d7439363338644f38646674416a74636f2f3230302e77656270.webp" width="50"><img src="https://raw.githubusercontent.com/Anmolnoor/Anmolnoor/master/gif%20profile/68747470733a2f2f692e67697068792e636f6d2f6d656469612f654e41736a4f353574506267616f72376d612f323030772e77656270.webp" width="50"><img src="https://raw.githubusercontent.com/Anmolnoor/Anmolnoor/master/gif%20profile/68747470733a2f2f6d65646961332e67697068792e636f6d2f6d656469612f6c6e377a32655772696951416c6c6656636e2f323030772e77656270.webp" width="50"><img src="https://raw.githubusercontent.com/Anmolnoor/Anmolnoor/master/gif%20profile/68747470733a2f2f6d65646961332e67697068792e636f6d2f6d656469612f6b64466338667562675333316238447356752f67697068792e77656270.webp" width="50"><img src="https://github.com/Anmolnoor/Anmolnoor/blob/master/gif%20profile/68747470733a2f2f6d65646961332e67697068792e636f6d2f6d656469612f55514a6c5a324f6361434132524c6647695a2f67697068792e676966.gif?raw=true" width="50"><img src="https://github.com/Anmolnoor/Anmolnoor/blob/master/gif%20profile/68747470733a2f2f6d65646961312e67697068792e636f6d2f6d656469612f5269325455634b6c614f63614442784670592f67697068792e676966.gif?raw=true" width="50"><img src="https://github.com/Anmolnoor/Anmolnoor/blob/master/gif%20profile/68747470733a2f2f6d65646961322e67697068792e636f6d2f6d656469612f5372387844704d77564b4f485557445652442f67697068792e676966.gif?raw=true" width="50"><img src="https://github.com/Anmolnoor/Anmolnoor/blob/master/gif%20profile/68747470733a2f2f6d65646961322e67697068792e636f6d2f6d656469612f584178796c524d43647062455755417672382f67697068792e676966.gif?raw=true" height="50"><img src="https://github.com/Anmolnoor/Anmolnoor/blob/master/gif%20profile/68747470733a2f2f6d65646961312e67697068792e636f6d2f6d656469612f667345615a6c644e43384131504a336d77702f67697068792e676966.gif?raw=true" width="50"><img src="https://github.com/Anmolnoor/Anmolnoor/blob/master/gif%20profile/68747470733a2f2f6d65646961312e67697068792e636f6d2f6d656469612f6a357a5939464b4777703159565a325946562f67697068792e676966.gif?raw=true" width="50"><img src="https://github.com/Anmolnoor/Anmolnoor/blob/master/gif%20profile/68747470733a2f2f6d65646961332e67697068792e636f6d2f6d656469612f6b48364371596971755a61776d55314849362f67697068792e6769663f6369643d656366303565343736656633613262613365336462363036393735386335333035313637303.gif?raw=true" height="50"><img src="https://github.com/Anmolnoor/Anmolnoor/blob/master/gif%20profile/68747470733a2f2f6d65646961302e67697068792e636f6d2f6d656469612f4b7a4a6b7a6a676766474e355079366e6b542f67697068792e676966.gif?raw=true" width="50"><img src="https://github.com/Anmolnoor/Anmolnoor/blob/master/gif%20profile/68747470733a2f2f6d2e6769666d616e69612e636f2e756b2f5765622d44657369676e2d416e696d617465642d476966732f416e696d617465642d5369676e732d57656273697465732f4a6176612d5369676e732f4a6176612d4c6f676f2d36323239312e6.gif?raw=true" width="50">
+
+ 
+ 
+ <!-- 
+<img alt="CSS3" src="https://img.shields.io/badge/css3%20-%231572B6.svg?&style=for-the-badge&logo=css3&logoColor=white" style="margin:2px;"/>
+<img alt="Bootstrap" src="https://img.shields.io/badge/bootstrap%20-%23563D7C.svg?&style=for-the-badge&logo=bootstrap&logoColor=white" style="margin:2px;"/>
+<img alt="C" src="https://img.shields.io/badge/c%20-%2300599C.svg?&style=for-the-badge&logo=c&logoColor=white" style="margin:2px;"/>
+<img alt="Python" src="https://img.shields.io/badge/python%20-%2314354C.svg?&style=for-the-badge&logo=python&logoColor=white" style="margin:2px;"/>
+<img alt="JavaScript" src="https://img.shields.io/badge/javascript%20-%23323330.svg?&style=for-the-badge&logo=javascript&logoColor=%23F7DF1E" style="margin:2px;"/>
+<img alt="C++" src="https://img.shields.io/badge/c++%20-%2300599C.svg?&style=for-the-badge&logo=c%2B%2B&ogoColor=white" style="margin:2px;"/>
+<img alt="React" src="https://img.shields.io/badge/react%20-%2320232a.svg?&style=for-the-badge&logo=react&logoColor=%2361DAFB" style="margin:2px;"/>
+<img alt="NodeJS" src="https://img.shields.io/badge/node.js%20-%2343853D.svg?&style=for-the-badge&logo=node.js&logoColor=white" style="margin:2px;"/>
+<img alt="Git" src="https://img.shields.io/badge/git%20-%23F05033.svg?&style=for-the-badge&logo=git&logoColor=white" style="margin:2px;"/>
+<img alt="GitHub" src="https://img.shields.io/badge/github%20-%23121011.svg?&style=for-the-badge&logo=github&logoColor=white" style="margin:2px;"/>
+<img alt="WordPress" src="https://img.shields.io/badge/WordPress%20-%23117AC9.svg?&style=for-the-badge&logo=WordPress&logoColor=white" style="margin:2px;"/>
+<img alt="MongoDB" src ="https://img.shields.io/badge/MongoDB-%234ea94b.svg?&style=for-the-badge&logo=mongodb&logoColor=white" style="margin:2px;"/>
+-->
+<br/>
+</p>
+
+
+
+# 🏆 *Github Status*
+<!--&theme=dark  -->
+<!-- <img  src="https://github-readme-stats.vercel.app/api?username=Anmolnoor&show_icons=true&hide_border=true" width="48%" align="right" > -->
+<!-- &theme=dark -->
+<!-- <img  src="https://github-readme-streak-stats.herokuapp.com/?user=Anmolnoor" width="48%" > -->
+
+<!-- <div align="center">
+ 
+ [![trophy](https://github-profile-trophy.vercel.app/?username=anmolnoor&margin-w=15&column=7)](https://github.com/anmolnoor/github-profile-trophy)
+
+</div> -->
+
+<br/>
+<br/>
+
+[![Anmol_Noor's github activity graph](https://github-readme-activity-graph.vercel.app/graph?username=AnmolNoor&bg_color=8ad6a3&color=2a322b&line=4f97e3&point=162315&area=true&hide_border=true)](https://github.com/ashutosh00710/github-readme-activity-graph)
+
+<br/>
+<br/> 
+
+<!-- 
+# 🔗 Connect with me:
+
+<p align="left">
+
+<a href = "https://www.linkedin.com/in/anmol-noor/"><img src="https://img.icons8.com/fluent/48/000000/linkedin.png"/></a>
+<a href = "https://www.instagram.com/_anmol_noor/"><img src="https://img.icons8.com/fluent/48/000000/instagram-new.png"/></a>
+</p>
+ -->
+
+
+![Snake animation](https://raw.githubusercontent.com/Anmolnoor/Anmolnoor/output/snake/github-contribution-grid-snake.svg)
+
+
+
+<!-- If you switch services in the future, check for a 'base' or 'offset' parameter to carry over your count (Current base: 4265) -->
+![Visitor Badge](https://komarev.com/ghpvc/?username=Anmolnoor&label=visitors&color=0e75b6&style=flat&base=4265)
+<a href="https://github.com/Anmolnoor?tab=followers"><img src="https://img.shields.io/github/followers/Anmolnoor?label=Followers&style=social" alt="GitHub Badge"></a>
+
+
+  
+
+

--- a/README.md
+++ b/README.md
@@ -36,8 +36,42 @@ More product work: Amend Notes, [Vendro](https://www.anmolnoor.com/vendro), and 
 
 ## Stack
 
-TypeScript, React, Next.js, Node.js, Express, Python, Shell, PostgreSQL, MongoDB, Prisma, Tailwind CSS, WebRTC, Socket.io, Solana, Git, Linux, Proxmox, Prometheus, and Grafana.
+<p>
+  <img alt="TypeScript" src="https://img.shields.io/badge/TypeScript-3178C6?style=for-the-badge&logo=typescript&logoColor=white">
+  <img alt="React" src="https://img.shields.io/badge/React-20232A?style=for-the-badge&logo=react&logoColor=61DAFB">
+  <img alt="Next.js" src="https://img.shields.io/badge/Next.js-000000?style=for-the-badge&logo=nextdotjs&logoColor=white">
+  <img alt="Node.js" src="https://img.shields.io/badge/Node.js-339933?style=for-the-badge&logo=nodedotjs&logoColor=white">
+  <img alt="Python" src="https://img.shields.io/badge/Python-14354C?style=for-the-badge&logo=python&logoColor=white">
+  <img alt="CLI" src="https://img.shields.io/badge/CLI-111111?style=for-the-badge&logo=windowsterminal&logoColor=white">
+  <img alt="Codex" src="https://img.shields.io/badge/Codex-111111?style=for-the-badge&logo=openai&logoColor=white">
+  <img alt="PostgreSQL" src="https://img.shields.io/badge/PostgreSQL-316192?style=for-the-badge&logo=postgresql&logoColor=white">
+  <img alt="MongoDB" src="https://img.shields.io/badge/MongoDB-4EA94B?style=for-the-badge&logo=mongodb&logoColor=white">
+  <img alt="Prisma" src="https://img.shields.io/badge/Prisma-2D3748?style=for-the-badge&logo=prisma&logoColor=white">
+  <img alt="Tailwind CSS" src="https://img.shields.io/badge/Tailwind_CSS-38B2AC?style=for-the-badge&logo=tailwindcss&logoColor=white">
+  <img alt="WebRTC" src="https://img.shields.io/badge/WebRTC-333333?style=for-the-badge&logo=webrtc&logoColor=white">
+  <img alt="Solana" src="https://img.shields.io/badge/Solana-9945FF?style=for-the-badge&logo=solana&logoColor=white">
+  <img alt="Linux" src="https://img.shields.io/badge/Linux-FCC624?style=for-the-badge&logo=linux&logoColor=111111">
+  <img alt="macOS" src="https://img.shields.io/badge/macOS-111111?style=for-the-badge&logo=apple&logoColor=white">
+  <img alt="Proxmox" src="https://img.shields.io/badge/Proxmox-E57000?style=for-the-badge&logo=proxmox&logoColor=white">
+  <img alt="Prometheus" src="https://img.shields.io/badge/Prometheus-E6522C?style=for-the-badge&logo=prometheus&logoColor=white">
+  <img alt="Grafana" src="https://img.shields.io/badge/Grafana-F46800?style=for-the-badge&logo=grafana&logoColor=white">
+</p>
 
 ## Contact
 
-The fastest way to reach me is [email](mailto:anmolnoor59@gmail.com) or [Cal.com](https://cal.com/anmolnoor). You can also find me on [GitHub](https://github.com/Anmolnoor), [LinkedIn](https://www.linkedin.com/in/anmolnoor/), and [X](https://twitter.com/noor_anmol).
+<p>
+  <a href="https://www.anmolnoor.com/"><img alt="Portfolio" src="https://img.shields.io/badge/Portfolio-111111?style=for-the-badge&logo=googlechrome&logoColor=white"></a>
+  <a href="https://www.anmolnoor.com/blog"><img alt="Blog" src="https://img.shields.io/badge/Blog-0A0A0A?style=for-the-badge&logo=rss&logoColor=white"></a>
+  <a href="mailto:anmolnoor59@gmail.com"><img alt="Email" src="https://img.shields.io/badge/Email-D14836?style=for-the-badge&logo=gmail&logoColor=white"></a>
+  <a href="https://cal.com/anmolnoor"><img alt="Book a call" src="https://img.shields.io/badge/Book_a_call-111111?style=for-the-badge&logo=caldotcom&logoColor=white"></a>
+  <a href="https://github.com/Anmolnoor"><img alt="GitHub" src="https://img.shields.io/badge/GitHub-181717?style=for-the-badge&logo=github&logoColor=white"></a>
+  <a href="https://www.linkedin.com/in/anmolnoor/"><img alt="LinkedIn" src="https://img.shields.io/badge/LinkedIn-0A66C2?style=for-the-badge&logo=linkedin&logoColor=white"></a>
+  <a href="https://twitter.com/noor_anmol"><img alt="X" src="https://img.shields.io/badge/X-000000?style=for-the-badge&logo=x&logoColor=white"></a>
+</p>
+
+![Snake animation](https://raw.githubusercontent.com/Anmolnoor/Anmolnoor/output/snake/github-contribution-grid-snake.svg)
+
+
+<!-- If you switch services in the future, check for a 'base' or 'offset' parameter to carry over your count (Current base: 4265) -->
+![Visitor Badge](https://komarev.com/ghpvc/?username=Anmolnoor&label=visitors&color=0e75b6&style=flat&base=4265)
+<a href="https://github.com/Anmolnoor?tab=followers"><img src="https://img.shields.io/github/followers/Anmolnoor?label=Followers&style=social" alt="GitHub Badge"></a>

--- a/README.md
+++ b/README.md
@@ -57,16 +57,16 @@ More product work: Amend Notes, [Vendro](https://www.anmolnoor.com/vendro), and 
   <img alt="Grafana" src="https://img.shields.io/badge/Grafana-F46800?style=for-the-badge&logo=grafana&logoColor=white">
 </p>
 
-## Contact
+## Connect
 
 <p>
-  <a href="https://www.anmolnoor.com/"><img alt="Portfolio" src="https://img.shields.io/badge/Portfolio-111111?style=for-the-badge&logo=googlechrome&logoColor=white"></a>
-  <a href="https://www.anmolnoor.com/blog"><img alt="Blog" src="https://img.shields.io/badge/Blog-0A0A0A?style=for-the-badge&logo=rss&logoColor=white"></a>
-  <a href="mailto:anmolnoor59@gmail.com"><img alt="Email" src="https://img.shields.io/badge/Email-D14836?style=for-the-badge&logo=gmail&logoColor=white"></a>
-  <a href="https://cal.com/anmolnoor"><img alt="Book a call" src="https://img.shields.io/badge/Book_a_call-111111?style=for-the-badge&logo=caldotcom&logoColor=white"></a>
-  <a href="https://github.com/Anmolnoor"><img alt="GitHub" src="https://img.shields.io/badge/GitHub-181717?style=for-the-badge&logo=github&logoColor=white"></a>
-  <a href="https://www.linkedin.com/in/anmolnoor/"><img alt="LinkedIn" src="https://img.shields.io/badge/LinkedIn-0A66C2?style=for-the-badge&logo=linkedin&logoColor=white"></a>
-  <a href="https://twitter.com/noor_anmol"><img alt="X" src="https://img.shields.io/badge/X-000000?style=for-the-badge&logo=x&logoColor=white"></a>
+  <a href="https://twitter.com/noor_anmol"><img alt="X noor_anmol" src="https://img.shields.io/badge/X-noor__anmol-000000?style=for-the-badge&logo=x&logoColor=white"></a>
+  <a href="https://github.com/Anmolnoor"><img alt="GitHub Anmolnoor" src="https://img.shields.io/badge/GitHub-Anmolnoor-181717?style=for-the-badge&logo=github&logoColor=white"></a>
+  <a href="https://www.linkedin.com/in/anmolnoor/"><img alt="LinkedIn Anmol Noor" src="https://img.shields.io/badge/LinkedIn-Anmol%20Noor-0A66C2?style=for-the-badge&logo=linkedin&logoColor=white"></a>
+  <a href="https://www.anmolnoor.com/"><img alt="anmolnoor.com" src="https://img.shields.io/badge/anmolnoor.com-Portfolio-0EA5E9?style=for-the-badge&logo=googlechrome&logoColor=white"></a>
+  <a href="https://www.anmolnoor.com/blog"><img alt="Blog" src="https://img.shields.io/badge/Blog-Writing-FF5A1F?style=for-the-badge&logo=rss&logoColor=white"></a>
+  <a href="https://cal.com/anmolnoor"><img alt="Cal.com anmolnoor" src="https://img.shields.io/badge/Cal.com-anmolnoor-111111?style=for-the-badge&logo=caldotcom&logoColor=white"></a>
+  <a href="mailto:anmolnoor59@gmail.com"><img alt="Email anmolnoor59" src="https://img.shields.io/badge/Email-anmolnoor59-D14836?style=for-the-badge&logo=gmail&logoColor=white"></a>
 </p>
 
 ![Snake animation](https://raw.githubusercontent.com/Anmolnoor/Anmolnoor/output/snake/github-contribution-grid-snake.svg)

--- a/README.md
+++ b/README.md
@@ -1,163 +1,43 @@
-<!--
-[<img src="https://img.shields.io/badge/Github-%23eeeeee.svg?&style=for-the-badge&logo=github&logoColor=black">](https://github.com/Anmolnoor)
-[<img alt="Gmail" src="https://img.shields.io/badge/Gmail-D14836?style=for-the-badge&logo=gmail&logoColor=white" />](mailto:anmolnoor59@gmail.com)
-[<img src="https://img.shields.io/badge/linkedin-%230077B5.svg?&style=for-the-badge&logo=linkedin&logoColor=white">](https://www.linkedin.com/in/anmol-noor-47305013a)
-[<img alt="HackerRank" src="https://img.shields.io/badge/-Hackerrank-2EC866?style=for-the-badge&logo=HackerRank&logoColor=white"/>](https://www.hackerrank.com/anmolnoor59)
---> 
+# Anmol Noor
 
-# Hello <img src="https://github.com/TheDudeThatCode/TheDudeThatCode/blob/master/Assets/Earth.gif" width="24px">, *About [Me](https://github.com/Anmolnoor)*:
+Software engineer building full-stack applications, real-time systems, developer tools, and self-hosted infrastructure.
 
-**I'm Computer Engineer with a keen interest in Coding.**
+I care about clean architecture, performance, practical automation, and developer experience. In 2026, my public work is centered on coding agents, governed tool execution, CLI workflows, and homelab infrastructure.
 
-<!-- - 🔭 I’m currently working at **[Dynamic Nexus Solutions](https://www.dynamicnexussolutions.com/)** -->
+[Portfolio](https://www.anmolnoor.com/) | [Blog](https://www.anmolnoor.com/blog) | [GitHub](https://github.com/Anmolnoor) | [Book a call](https://cal.com/anmolnoor) | [Email](mailto:anmolnoor59@gmail.com) | [LinkedIn](https://www.linkedin.com/in/anmolnoor/) | [X](https://twitter.com/noor_anmol)
 
-- 💥 I'm Founder of **[Dynamic Nexus Solutions](https://www.dynamicnexussolutions.com/)** & **[Chain Commerce](https://github.com/Chain-Commerce)**
+## Now
 
-- 🔭 I’m currently working with **MERN** | **Web3** | **Solana** | **webRTC** | **MediaSoup** | **Astro** | **Nextjs**
+- Building [Foundation CLI](https://www.anmolnoor.com/blog/foundation-cli), a public coding-agent and developer-tooling project.
+- Open-sourcing governed agent infrastructure through [Beekeeper](https://github.com/Anmolnoor/beekeeper) and [agent-policy-gate](https://github.com/Anmolnoor/agent-policy-gate).
+- Running and documenting a homelab foundation with Proxmox, Pi-hole, shared storage, monitoring, dashboards, and automation.
+- Continuing product work across full-stack apps, real-time systems, Web3 experiments, and developer workflows.
 
-- 🌱 I’m currently learning **CI/CD**
+## Selected Work
 
-- 👯 I’m looking to collaborate on **OpenSource Projects**
+| Project | Focus |
+| --- | --- |
+| [fcli](https://github.com/Anmolnoor/fcli) | Foundation CLI: a coding-agent/dev-tooling project built in public. |
+| [beekeeper](https://github.com/Anmolnoor/beekeeper) | Governed multi-agent runtime and contribution model for safer agent workflows. |
+| [agent-policy-gate](https://github.com/Anmolnoor/agent-policy-gate) | Small policy, review, and audit primitives for gating agent tool calls. |
+| [scripts](https://github.com/Anmolnoor/scripts) | Personal shell scripts and setup shortcuts for a consistent dev environment. |
+| [claude-dotfiles](https://github.com/Anmolnoor/claude-dotfiles) | Portable Claude Code setup for quickly rebuilding an agent-ready machine. |
+| [my-portfolio](https://github.com/Anmolnoor/my-portfolio) | Source for my current portfolio, blog, project list, and public writing. |
 
-- 👨‍💻 All of my projects are available at **[My Portfolio](https://anmolnoor.com)**
+More product work: Amend Notes, [Vendro](https://www.anmolnoor.com/vendro), and [NFT Dropper](https://nft-drop-gold.vercel.app/). Earlier learning projects and experiments are listed on my [projects page](https://www.anmolnoor.com/projects) and [GitHub profile](https://github.com/Anmolnoor).
 
-- 📫 How to reach me **anmolnoor59@gmail.com** or book a [Meet](https://cal.com/anmolnoor)
+## Writing
 
-- ⚡ Fun fact I like **VSCode | Linux**
+- [Why I Open-Sourced Beekeeper Behind a Wall - and What's Inside It](https://www.anmolnoor.com/blog/beekeeper)
+- [I'm building a coding agent in public - and the lessons start before the code](https://www.anmolnoor.com/blog/foundation-cli)
+- [My Homelab Current Setup](https://www.anmolnoor.com/blog/homelab-current-setup)
+- [A terminal that does the boring parts for you](https://www.anmolnoor.com/blog/scripts)
+- [Hello, World - Why I'm Starting a Blog](https://www.anmolnoor.com/blog/hello-world)
 
-# 🏫 *Education*:
+## Stack
 
-### Bachelor of Technology in Computer Science and Engineering.</br>
-2018-2022 - Bhai Gurdas Institute of Engineering and Technology, Sangrur.
+TypeScript, React, Next.js, Node.js, Express, Python, Shell, PostgreSQL, MongoDB, Prisma, Tailwind CSS, WebRTC, Socket.io, Solana, Git, Linux, Proxmox, Prometheus, and Grafana.
 
-# ⚙️ *Skills*:
+## Contact
 
-- Web3 Developer 
-- Solana web3 Developer
-- React Native Development 
-- Android Development 
-- MERN Development 
-- Front-End with React, Next 
-- Back-End with NodeJS, Express, Axios 
-- Database Such as MongoDb, MySQL, Firebase 
-- CSS FrameWork BootStrap, Tailwind, Material_UI, Mantine
-- UI/UX Designing with Figma, AdobeXD, Photoshop 
-- Linux User & Git/GitHub 
-- Problem Solving & Interpersonal Skill 
-
-# 🛠️ *My Experience*:
-
-- **Frontend Engineer at [Huddle01](https://huddle01.com) - I have worked on frontend of [Huddle01](https://huddle01.com) website as Frontend Engineer. Also got the opportunity to work with webRTC, Mediasuop, Sockets.**
-
-- **React Native Intern at [Fortec Solution](https://fortecsolution.com/) - I have worked on Complaint Ticket Booking App of [Protocol Solutions](https://protocolsolution.com/). It was fully automated Ticket Generator using React-Native as Frontend and PHP based API. I have also work on App UI/UX.**
-
-- **Team Lead at [SWPL]() - I have worked with team of 5 Developer. We worked on Two projects, which are Rural Paisa and Full Stop in MERN Stack.**
-
-- **Web-Developer Internship at [ALS](https://autumnleavessolutions.com/)  - I have complete my 1 month Internship which include 3 projects. Such as Single Page website(landing page), College ERP, E-commerce (ReactJS).**
-
-
-
-# 💻 *Projects*:
-
-- **[NFT Droper](http://nft-drop-gold.vercel.app/)** It is a NFT droper on Solana Chain </br>
-- **[D-twitter](https://d-itter.netlify.app/#/)** It is a decentralised Twitter </br>
-- **[wallet-dapp](https://6205df9cef9c0122a08aba3a--sleepy-galileo-ce19c5.netlify.app/)** It is a Solana wallet playground </br>
-- **[Image-Portal](https://upbeat-bartik-f06847.netlify.app/)** It is a buildspace Solana IMG Portal Project </br>
-- **[solana-riptide-leader-board](http://solana-riptide-leader-board.vercel.app/)** Leader board of the Solana riptide Hackathon **XD** </br>
-- **[Flashback](https://github.com/Anmolnoor/flashback)** RealTime Social Media WebAPP with **_MERN_** along with **_uploading posts, like , share , delete._**</br>
-- **[Next Events](https://next-event-livid.vercel.app/)** It is a Nextjs application with all benefits of next js </br>
-- **[Meetup](https://meetup-smoky.vercel.app/)** It is a React application with all benefits of Reactjs </br>
-- **[Next Routing](https://next-routing-ebon.vercel.app/)** It is a Nextjs application for testing routing </br>
-- **[natours](https://natours-ej3e.onrender.com)** It is a **Full Backend** for a tours website with full security </br>
-- **[Reservation System](https://reservation-system-ten.vercel.app/)** It is a reservation system in TS </br>
-- **[_EJS and NodeJS + Express_](https://bgiet.onrender.com)** Based College Task management System.</br>
-- **[Node Farm](https://node-farm-vwne.onrender.com)** It is a website with just node js </br>
-- **[Security](https://security-syjk.onrender.com)** A Simple Login and Registration app with Implementing Various Encryptions Such as **_BcryptJS, OAuth, Hashing_**, etc.</br>
-- **[Todo List](https://todo-list-with-db.onrender.com)** A todo list with MongoDB database to store states </br>
-- **[Daily Journal](https://blog-with-database-41fd.onrender.com/)** Blog Application with **_MongoDB_** database on **_Express_** server.</br>
-- **[News letter](https://github.com/Anmolnoor/Newsletter-Singup)** It is a newsletter with Mailchimp </br>
-- **[Weather Project](https://github.com/Anmolnoor/weather-project)** app along with **_API_** from Open weather map.</br>
-- **[Simon Game](https://anmolnoor.github.io/Simon-Game/)** It is a Simon game </br>
-- **[Drum Kit](https://anmolnoor.github.io/Drum_Kit/)** It is a Drumkit in Website </br>
-- **[Dice Roll](https://anmolnoor.github.io/Dice_Roller/)** It is a Dice roller.</br>
-- **[Tindog](https://anmolnoor.me/TinDog/)** A tinder for dogs </br>
-- **[Vim Cheatsheet](https://github.com/Anmolnoor/vimCS/blob/main/README.md)**</br>
-- **[Markdown syntax Cheat sheet](https://github.com/Anmolnoor/markdownSCS/blob/main/README.md)**\
-
-Complaint Ticket Booking Project with **_React Native_** for Protocol Solutions.</br>
-A Login and Registration with **_JWT Tokens_** with Private routing and access control.</br>
-
-# 🔨 *Tech Stack I am Familiar With*:
-
-<p align="center" >
-<!-- <br/>  <a href="https://github.com/Anmolnoor/github-readme-stats"><img alt="Anmol Noor's Top Languages" src="https://github-readme-stats.vercel.app/api/top-langs/?username=Anmolnoor&langs_count=8&count_private=true&layout=compact&theme=react&hide_border=true&bg_color=0D1117" /></a> -->
-  <br/><br/>
-  <b>Note:</b> Top languages is only a metric of the languages my public code consists of and doesn't reflect experience or skill level.
-
- <br/>
-  <img src="https://raw.githubusercontent.com/Anmolnoor/Anmolnoor/master/gif%20profile/68747470733a2f2f692e67697068792e636f6d2f6d656469612f49647941514a564e326b56504e55726f6a4d2f3230302e77656270.webp" width="50"><img src="https://raw.githubusercontent.com/Anmolnoor/Anmolnoor/master/gif%20profile/68747470733a2f2f692e67697068792e636f6d2f6d656469612f4c4d7439363338644f38646674416a74636f2f3230302e77656270.webp" width="50"><img src="https://raw.githubusercontent.com/Anmolnoor/Anmolnoor/master/gif%20profile/68747470733a2f2f692e67697068792e636f6d2f6d656469612f654e41736a4f353574506267616f72376d612f323030772e77656270.webp" width="50"><img src="https://raw.githubusercontent.com/Anmolnoor/Anmolnoor/master/gif%20profile/68747470733a2f2f6d65646961332e67697068792e636f6d2f6d656469612f6c6e377a32655772696951416c6c6656636e2f323030772e77656270.webp" width="50"><img src="https://raw.githubusercontent.com/Anmolnoor/Anmolnoor/master/gif%20profile/68747470733a2f2f6d65646961332e67697068792e636f6d2f6d656469612f6b64466338667562675333316238447356752f67697068792e77656270.webp" width="50"><img src="https://github.com/Anmolnoor/Anmolnoor/blob/master/gif%20profile/68747470733a2f2f6d65646961332e67697068792e636f6d2f6d656469612f55514a6c5a324f6361434132524c6647695a2f67697068792e676966.gif?raw=true" width="50"><img src="https://github.com/Anmolnoor/Anmolnoor/blob/master/gif%20profile/68747470733a2f2f6d65646961312e67697068792e636f6d2f6d656469612f5269325455634b6c614f63614442784670592f67697068792e676966.gif?raw=true" width="50"><img src="https://github.com/Anmolnoor/Anmolnoor/blob/master/gif%20profile/68747470733a2f2f6d65646961322e67697068792e636f6d2f6d656469612f5372387844704d77564b4f485557445652442f67697068792e676966.gif?raw=true" width="50"><img src="https://github.com/Anmolnoor/Anmolnoor/blob/master/gif%20profile/68747470733a2f2f6d65646961322e67697068792e636f6d2f6d656469612f584178796c524d43647062455755417672382f67697068792e676966.gif?raw=true" height="50"><img src="https://github.com/Anmolnoor/Anmolnoor/blob/master/gif%20profile/68747470733a2f2f6d65646961312e67697068792e636f6d2f6d656469612f667345615a6c644e43384131504a336d77702f67697068792e676966.gif?raw=true" width="50"><img src="https://github.com/Anmolnoor/Anmolnoor/blob/master/gif%20profile/68747470733a2f2f6d65646961312e67697068792e636f6d2f6d656469612f6a357a5939464b4777703159565a325946562f67697068792e676966.gif?raw=true" width="50"><img src="https://github.com/Anmolnoor/Anmolnoor/blob/master/gif%20profile/68747470733a2f2f6d65646961332e67697068792e636f6d2f6d656469612f6b48364371596971755a61776d55314849362f67697068792e6769663f6369643d656366303565343736656633613262613365336462363036393735386335333035313637303.gif?raw=true" height="50"><img src="https://github.com/Anmolnoor/Anmolnoor/blob/master/gif%20profile/68747470733a2f2f6d65646961302e67697068792e636f6d2f6d656469612f4b7a4a6b7a6a676766474e355079366e6b542f67697068792e676966.gif?raw=true" width="50"><img src="https://github.com/Anmolnoor/Anmolnoor/blob/master/gif%20profile/68747470733a2f2f6d2e6769666d616e69612e636f2e756b2f5765622d44657369676e2d416e696d617465642d476966732f416e696d617465642d5369676e732d57656273697465732f4a6176612d5369676e732f4a6176612d4c6f676f2d36323239312e6.gif?raw=true" width="50">
-
- 
- 
- <!-- 
-<img alt="CSS3" src="https://img.shields.io/badge/css3%20-%231572B6.svg?&style=for-the-badge&logo=css3&logoColor=white" style="margin:2px;"/>
-<img alt="Bootstrap" src="https://img.shields.io/badge/bootstrap%20-%23563D7C.svg?&style=for-the-badge&logo=bootstrap&logoColor=white" style="margin:2px;"/>
-<img alt="C" src="https://img.shields.io/badge/c%20-%2300599C.svg?&style=for-the-badge&logo=c&logoColor=white" style="margin:2px;"/>
-<img alt="Python" src="https://img.shields.io/badge/python%20-%2314354C.svg?&style=for-the-badge&logo=python&logoColor=white" style="margin:2px;"/>
-<img alt="JavaScript" src="https://img.shields.io/badge/javascript%20-%23323330.svg?&style=for-the-badge&logo=javascript&logoColor=%23F7DF1E" style="margin:2px;"/>
-<img alt="C++" src="https://img.shields.io/badge/c++%20-%2300599C.svg?&style=for-the-badge&logo=c%2B%2B&ogoColor=white" style="margin:2px;"/>
-<img alt="React" src="https://img.shields.io/badge/react%20-%2320232a.svg?&style=for-the-badge&logo=react&logoColor=%2361DAFB" style="margin:2px;"/>
-<img alt="NodeJS" src="https://img.shields.io/badge/node.js%20-%2343853D.svg?&style=for-the-badge&logo=node.js&logoColor=white" style="margin:2px;"/>
-<img alt="Git" src="https://img.shields.io/badge/git%20-%23F05033.svg?&style=for-the-badge&logo=git&logoColor=white" style="margin:2px;"/>
-<img alt="GitHub" src="https://img.shields.io/badge/github%20-%23121011.svg?&style=for-the-badge&logo=github&logoColor=white" style="margin:2px;"/>
-<img alt="WordPress" src="https://img.shields.io/badge/WordPress%20-%23117AC9.svg?&style=for-the-badge&logo=WordPress&logoColor=white" style="margin:2px;"/>
-<img alt="MongoDB" src ="https://img.shields.io/badge/MongoDB-%234ea94b.svg?&style=for-the-badge&logo=mongodb&logoColor=white" style="margin:2px;"/>
--->
-<br/>
-</p>
-
-
-
-# 🏆 *Github Status*
-<!--&theme=dark  -->
-<!-- <img  src="https://github-readme-stats.vercel.app/api?username=Anmolnoor&show_icons=true&hide_border=true" width="48%" align="right" > -->
-<!-- &theme=dark -->
-<!-- <img  src="https://github-readme-streak-stats.herokuapp.com/?user=Anmolnoor" width="48%" > -->
-
-<!-- <div align="center">
- 
- [![trophy](https://github-profile-trophy.vercel.app/?username=anmolnoor&margin-w=15&column=7)](https://github.com/anmolnoor/github-profile-trophy)
-
-</div> -->
-
-<br/>
-<br/>
-
-[![Anmol_Noor's github activity graph](https://github-readme-activity-graph.vercel.app/graph?username=AnmolNoor&bg_color=8ad6a3&color=2a322b&line=4f97e3&point=162315&area=true&hide_border=true)](https://github.com/ashutosh00710/github-readme-activity-graph)
-
-<br/>
-<br/> 
-
-<!-- 
-# 🔗 Connect with me:
-
-<p align="left">
-
-<a href = "https://www.linkedin.com/in/anmol-noor/"><img src="https://img.icons8.com/fluent/48/000000/linkedin.png"/></a>
-<a href = "https://www.instagram.com/_anmol_noor/"><img src="https://img.icons8.com/fluent/48/000000/instagram-new.png"/></a>
-</p>
- -->
-
-
-![Snake animation](https://raw.githubusercontent.com/Anmolnoor/Anmolnoor/output/snake/github-contribution-grid-snake.svg)
-
-
-
-<!-- If you switch services in the future, check for a 'base' or 'offset' parameter to carry over your count (Current base: 4265) -->
-![Visitor Badge](https://komarev.com/ghpvc/?username=Anmolnoor&label=visitors&color=0e75b6&style=flat&base=4265)
-<a href="https://github.com/Anmolnoor?tab=followers"><img src="https://img.shields.io/github/followers/Anmolnoor?label=Followers&style=social" alt="GitHub Badge"></a>
-
-
-  
-
-
+The fastest way to reach me is [email](mailto:anmolnoor59@gmail.com) or [Cal.com](https://cal.com/anmolnoor). You can also find me on [GitHub](https://github.com/Anmolnoor), [LinkedIn](https://www.linkedin.com/in/anmolnoor/), and [X](https://twitter.com/noor_anmol).


### PR DESCRIPTION
## Summary
- refresh the profile README around current 2026 work and public writing
- add README.before-2026.md as an exact backup of the previous README
- feature current projects: fcli, beekeeper, agent-policy-gate, scripts, claude-dotfiles, and my-portfolio

## Validation
- verified README.before-2026.md hash matches origin/master:README.md
- rendered README through GitHub Markdown API
- checked public project, portfolio, blog, Cal.com, and GitHub links

## Notes
LinkedIn and X/Twitter could not be curl-verified from the local resolver because those hosts resolve to 0.0.0.0 here; the links match the current portfolio.